### PR TITLE
Change preprocessed data path after OSL has renamed it

### DIFF
--- a/analysis/3_coregister-and-source-recon-bulk.py
+++ b/analysis/3_coregister-and-source-recon-bulk.py
@@ -94,7 +94,7 @@ for sub_run_combo in sub_run_combos:
     # set paths for where to look for necessary files
     anat_dir = coinsmeg.get_sub_anat_dir(subject_id)
     smri_file = f"{anat_dir}/{subject_id}_T1w.nii"
-    fif_file = f'{preproc_dir}/{subject_id}_ses-2-meg_task-coinsmeg_{run_id}_meg_transsss/{subject_id}_ses-2-meg_task-coinsmeg_{run_id}_meg_transsss_preproc_raw.fif'
+    fif_file = coinsmeg.get_sub_preproc_raw_fname(subject_id, run_id)
     
     if not os.path.exists(smri_file):
         print(f"WARNING: smri_file does not exist for {sub_run_combo}!")

--- a/analysis/coinsmeg_data.py
+++ b/analysis/coinsmeg_data.py
@@ -123,10 +123,16 @@ def get_sub_preproc_dir(sub, run):
     subdir = f"{sub_num2str(sub)}_ses-2-meg_task-coinsmeg_run-{run}_meg_transsss"
     return op.join(PREPROCESSED_DIR, subdir)
 
-def get_sub_preproc_raw_fname(sub, run):
-    """Name of the .fif file containing the preprocessed MEG data for a given
-    subject and run, which can be loaded as a MNE Raw object."""
-    return f"{sub_num2str(sub)}_ses-2-meg_task-coinsmeg_run-{run}_meg_transsss_preproc_raw.fif"
+def get_sub_preproc_raw_fname(sub, run, suffix="preproc-raw"):
+    """
+    Name of the .fif file containing the preprocessed MEG data for a given
+    subject and run, which can be loaded as a MNE Raw object.
+    
+    The 'suffix' parameter should reflect the value that was used for the 
+    'ftype' parameter in osl.preprocessing.run_proc_chain().
+    At the time this docstring was written, the default value for ftype is "preproc-raw".
+    """
+    return f"{sub_num2str(sub)}_ses-2-meg_task-coinsmeg_run-{run}_meg_transsss_{suffix}.fif"
 
 def get_sub_preproc_raw_fpath(sub, run):
     """Path to the .fif file containing the preprocessed MEG data for a given


### PR DESCRIPTION
Resolves #26.

- Change "preproc_raw" to "preproc-raw" in the coinsmeg module function to get the path to the preprocessed data.
- Use the coinsmeg function in the coregister-and-source-recon-bulk script so that this change of path, and any possible future changes, are reflected in this script.