### PR TITLE
PR for #28

### DIFF
--- a/analysis/3_coregister-and-source-recon-bulk.py
+++ b/analysis/3_coregister-and-source-recon-bulk.py
@@ -50,7 +50,7 @@ def copy_polhemus_files(polhemus_dir, recon_dir, subject):
 parser = argparse.ArgumentParser(description="Run coregistration and source reconstruction for MEG data.")
 parser.add_argument(
     '--parcellation_version', 
-    default='Glasser52_binary_space-MNI152NLin6_res-1x1x1',
+    default=coinsmeg.PARC_NAME,
     type=str, 
     required=False, 
     help="Specify the parcellation version to use for source reconstruction."
@@ -244,8 +244,9 @@ for sub_run_combo in sub_run_combos:
     print(f"Dimensions of parc_raw are (nparcels x all_tpts) = {parc_raw.get_data().shape}")
 
     # source space data directory
-    parc_dir = op.join(coinsmeg.SRC_DIR, sub_run_combo, parcellation_version) # directory for saving the parcellated file
+    parc_dir = coinsmeg.get_sub_parc_dir(subject_id, run_id, parc_name=parcellation_version)
     os.makedirs(parc_dir, exist_ok=True)
 
     # save parc_raw into the src_dir
-    parc_raw.save(op.join(parc_dir, "parc_raw.fif"), overwrite=True)
+    parc_file = coinsmeg.get_sub_parc_fpath(subject_id, run_id, parc_name=parcellation_version)
+    parc_raw.save(parc_file, overwrite=True)

--- a/analysis/cf_trf.py
+++ b/analysis/cf_trf.py
@@ -127,7 +127,7 @@ def get_XY_singlerun(sub, run, event_names,
     if "sensor" in spaces:
         paths["sensorspc"] = coinsmeg.get_sub_preproc_raw_fpath(sub, run)
     if "source" in spaces:
-        paths["sourcespc"] = coinsmeg.get_sub_src_parc_fpath(sub, run)
+        paths["sourcespc"] = coinsmeg.get_sub_parc_fpath(sub, run)
     if do_locally:
         for k, fpath in paths.items():
             paths[k] = utils.get_local_path_for_data(fpath)

--- a/analysis/cf_trf_estimate_allsubs.py
+++ b/analysis/cf_trf_estimate_allsubs.py
@@ -77,7 +77,7 @@ def main(args):
         has_all_sensorspc_data = all([op.exists(cf_utils.get_path_for_data(
             coinsmeg.get_sub_preproc_raw_fpath(sub, run), do_locally)) for run in coinsmeg.RUNS])
         has_all_sourcespc_data = all([op.exists(cf_utils.get_path_for_data(
-            coinsmeg.get_sub_src_parc_fpath(sub, run), do_locally)) for run in coinsmeg.RUNS])
+            coinsmeg.get_sub_parc_fpath(sub, run), do_locally)) for run in coinsmeg.RUNS])
         if has_all_sensorspc_data:
             spaces += ["sensor"]
             datatypes += ["mag", "grad"]

--- a/analysis/coinsmeg_data.py
+++ b/analysis/coinsmeg_data.py
@@ -172,7 +172,7 @@ def get_sub_parc_dir(sub, run, parc_name=PARC_NAME):
     parcellation."""
     return op.join(get_sub_src_dir(sub, run), parc_name)
 
-def get_sub_src_parc_fpath(sub, run, parc_name=PARC_NAME):
+def get_sub_parc_fpath(sub, run, parc_name=PARC_NAME):
     """Path to the .fif file containing the source-reconstructed MEG data
     for a given subject and run, parcellated by brain region of the given
     parcellation, and loadable as a MNE Raw object."""

--- a/analysis/coinsmeg_data.py
+++ b/analysis/coinsmeg_data.py
@@ -38,6 +38,9 @@ PREPROCESSED_DIR = op.join(DERIVATIVES_DIR, "preprocessed")
 # Directory containing source-space parcellated data
 SRC_DIR = op.join(DERIVATIVES_DIR, "src")
 
+# Name of the default parcellation
+PARC_NAME = "Glasser52_binary_space-MNI152NLin6_res-1x1x1"
+
 #
 # Definitions of events, conditions, and other experiment-related information.
 #
@@ -163,10 +166,16 @@ def get_sub_src_dir(sub, run):
     for a given subject and run."""
     return op.join(SRC_DIR, f"{get_sub(sub)}_{get_run(run)}")
 
-def get_sub_src_parc_fpath(sub, run):
+def get_sub_parc_dir(sub, run, parc_name=PARC_NAME):
+    """Path to the directory containing the source-reconstructed MEG data
+    for a given subject and run, parcellated by brain region of the given
+    parcellation."""
+    return op.join(get_sub_src_dir(sub, run), parc_name)
+
+def get_sub_src_parc_fpath(sub, run, parc_name=PARC_NAME):
     """Path to the .fif file containing the source-reconstructed MEG data
-    for a given subject and run, parcellated by brain region, and
-    loadable as a MNE Raw object."""
-    d = get_sub_src_dir(sub, run)
+    for a given subject and run, parcellated by brain region of the given
+    parcellation, and loadable as a MNE Raw object."""
+    d = get_sub_parc_dir(sub, run, parc_name=parc_name)
     fname = "parc_raw.fif"
     return op.join(d, fname)


### PR DESCRIPTION
Closes #28 

Put the paths/path components to the parcellated data saved by the source-recon script in the module coinsmeg_data, so that we can reuse them and avoid code duplication.