### PR TITLE
Issue 30: fix source recon subjects/runs

### DIFF
--- a/analysis/3_coregister-and-source-recon-bulk.py
+++ b/analysis/3_coregister-and-source-recon-bulk.py
@@ -96,10 +96,13 @@ for sub_run_combo in sub_run_combos:
     smri_file = f"{anat_dir}/{subject_id}_T1w.nii"
     fif_file = coinsmeg.get_sub_preproc_raw_fpath(subject_id, run_id)
     
-    if not os.path.exists(smri_file):
-        print(f"WARNING: smri_file does not exist for {sub_run_combo}!")
+    if (not os.path.exists(smri_file)) or (not os.path.exists(fif_file)):
+        if not os.path.exists(smri_file):
+            print(f"WARNING: smri_file does not exist for {sub_run_combo}!")
+        elif not os.path.exists(fif_file):
+            print(f"WARNING: preprocessed fif_file does not exist for {sub_run_combo}!")
         continue # skip over the rest of the code for this sub_run_combo
-
+    
     source_recon.rhino.compute_surfaces(
         smri_file,
         recon_dir,

--- a/analysis/3_coregister-and-source-recon-bulk.py
+++ b/analysis/3_coregister-and-source-recon-bulk.py
@@ -29,8 +29,6 @@ from mne import read_forward_solution
 from osl.source_recon.rhino.polhemus import extract_polhemus_from_info
 from osl.source_recon import rhino, beamforming, parcellation # for calculating beamformer weights
 
-import re
-
 # functions
 def copy_polhemus_files(polhemus_dir, recon_dir, subject):
     polhemus_headshape = np.loadtxt(op.join(polhemus_dir, 'polhemus_headshape.txt'))
@@ -69,53 +67,21 @@ data_dir = coinsmeg.RAW_DIR # this is the same as BASE_DIR as raw data is stored
 preproc_dir = coinsmeg.PREPROCESSED_DIR
 recon_dir = op.join(coinsmeg.DERIVATIVES_DIR, "recon")
 
-############## ------- Get subjects and runs  ---------- ############
+# Get subjects
+subs = []
 
-# Do a reverse search to see which subs/runs exist in the preprocessed data directory
-# Do dynamic pattern generation based on get_sub_preproc_raw_fname
+data_sub_folders = sorted(filter(lambda path: "sub-" in path, glob(data_dir + '/*'))) # returns a list of paths e.g., '/ohba/pi/lhunt/datasets/coins-meg_data/sub-22'
 
-def generate_pattern(suffix="preproc-raw"):
-    # Example placeholders for 'sub' and 'run'
-    sub_placeholder = "sub-\\d+"
-    run_placeholder = "run-\\d+"
+for subject in data_sub_folders:
+    subs.append(pathlib.Path(subject).stem) # subs is now a list of ['sub-01', 'sub-02', ...]
 
-    # Get the template filename using placeholders
-    template_fname = coinsmeg.get_sub_preproc_raw_fname(sub_placeholder, run_placeholder, suffix=suffix)
+# Create a list with '_run-X' appended for each subject
+sub_run_combos = []
+for sub in subs:
+    for run in range(1, 5):  # Loop from 1 to 4
+        sub_run_combos.append(f"{sub}_run-{run}") # sub_run_combos is now a list of ['sub-01_run-1', 'sub-01_run-2', ...]
 
-    # Escape the generated template filename
-    template_pattern = re.escape(template_fname)
-
-    # Replace placeholders with regex groups
-    template_pattern = template_pattern.replace(re.escape(sub_placeholder), r"(?P<sub>sub-\d+)")
-    template_pattern = template_pattern.replace(re.escape(run_placeholder), r"(?P<run>run-\d+)")
-    return re.compile(template_pattern)
-
-def find_sub_run_combos(preprocessed_dir, suffix="preproc-raw"):
-    # Generate a pattern specific to the given suffix
-    pattern = generate_pattern(suffix)
-
-    sub_run_combos = []
-
-    # Walk through the directory structure
-    for root, _, files in os.walk(preprocessed_dir):
-        for file in files:
-            match = pattern.match(file)
-            if match:
-                # Extract "sub" and "run" values
-                sub = match.group("sub")
-                run = match.group("run")
-                # Combine them into "sub_run_combos"
-                sub_run_combos.append(f"{sub}_{run}")
-
-    return sub_run_combos
-
-# Execute the reverse search
-sub_run_combos = find_sub_run_combos(coinsmeg.PREPROCESSED_DIR, suffix="preproc-raw")
-# Sort the list so that it's in ascending sub/runs
-sub_run_combos = sorted(sub_run_combos, key=lambda x: (int(x.split('_')[0].split('-')[1]), int(x.split('_')[1].split('-')[1])))
-
-# Print the results
-print(sub_run_combos)
+print(sub_run_combos) # eg ['sub-04_run-3'...]
 
 ############## -------  Run coregistration and source reconstruction   ---------- ############
 

--- a/analysis/3_coregister-and-source-recon-bulk.py
+++ b/analysis/3_coregister-and-source-recon-bulk.py
@@ -172,7 +172,7 @@ for sub_run_combo in sub_run_combos:
     )
 
     # now view result
-    source_recon.rhino.coreg_display(subjects_dir = "/ohba/pi/lhunt/datasets/coins-meg_data/derivatives/recon", 
+    source_recon.rhino.coreg_display(subjects_dir = recon_dir, 
                                     subject = sub_run_combo,
                                     filename = f"{recon_dir}/{sub_run_combo}/rhino/coreg/coreg_display_plot.html") # saves an interactive html plot at this location
 
@@ -197,8 +197,6 @@ for sub_run_combo in sub_run_combos:
 
     # load forward solution
     fwd_fname = op.join(recon_dir, sub_run_combo, "rhino", "model-fwd.fif") 
-    # tutorial said source_recon.rhino.get_coreg_filenames(recon_dir, subjects[0])["forward_model_file"]
-    # but this did not return a match for "forward_model_file"
     print(fwd_fname)
 
     fwd = read_forward_solution(fwd_fname)


### PR DESCRIPTION
This closes #30 by modifying `3_coregister-and-source-recon-bulk.py` such that it only processes subjects/runs for whom the preprocessed data exists. It achieves this by doing a reverse-search inside the preprocessed data directory to see which subs/runs exist there.